### PR TITLE
TEST : IncidentControllerTest, IncidentRepositoryTest 테스트 코드 작성 및 성공

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,10 +46,11 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    runtimeOnly 'com.h2database:h2'  // ✅ H2 인메모리 DB - H2로 빠르게 Swagger UI 띄우고 API 테스트부터 진행하려고.
+    //runtimeOnly 'com.h2database:h2'  // ✅ H2 인메모리 DB - H2로 빠르게 Swagger UI 띄우고 API 테스트부터 진행하려고.
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+    systemProperty "spring.profiles.active", "test"
     jvmArgs += ["-XX:+EnableDynamicAgentLoading"]
 }

--- a/src/main/java/com/andamiro/Dashboard/Dto/IncidentDTO/IncidentResponse.java
+++ b/src/main/java/com/andamiro/Dashboard/Dto/IncidentDTO/IncidentResponse.java
@@ -15,10 +15,10 @@ public record IncidentResponse(
         LocalDateTime happenedAt,
         LocalDateTime reportedAt,
         String status,
-        CreatorSummary creator
+        CreatorSummary creator //작성자 요약
 ) {
     public record CreatorSummary(
-            UUID id,
+            UUID id, // 작성자(User의 id) = 사고를 등록한 사용자의 id
             String name
     ){}
 

--- a/src/main/java/com/andamiro/Dashboard/Repository/IncidentRepository.java
+++ b/src/main/java/com/andamiro/Dashboard/Repository/IncidentRepository.java
@@ -10,12 +10,19 @@ import java.util.UUID;
 @Repository
 public interface IncidentRepository extends JpaRepository<Incident, UUID> {
 
+
     List<Incident> findByCreatorId(UUID creatorId);
     //SELECT * FROM incidents WHERE creator_id = ? 쿼리가 자동으로 생성돼.
     /*
     Q) 이거 DB에 컬럼명이랑 일치하는거 자동 변환하는거 어디서 흐름타고 이렇게 되는거임?
 
+    findByCreatorId → JPA는 여기서 Creator라는 필드명을 보고, Incident 엔티티 안의 creator 필드를 찾아감.
+    creator는 @ManyToOne User로 매핑돼 있을 거야.
 
+    그럼 JPA가 자동으로 이 User 엔티티의 id 컬럼을 참조하는 걸 파악하고
+    → SELECT * FROM incidents WHERE creator_id = ? 쿼리를 만들어 실행하는 거지.
+
+    즉, 메서드 이름 → 엔티티 필드 매핑 → DB 컬럼명 매핑 순서로 흘러가.
      */
 
 }

--- a/src/main/java/com/andamiro/Dashboard/Service/IncidentService.java
+++ b/src/main/java/com/andamiro/Dashboard/Service/IncidentService.java
@@ -31,9 +31,9 @@ public class IncidentService {
     public List<IncidentResponse> getListIncidents(UUID id) {
         List<Incident> incidents; //실제 엔티티(ERD설계한 테이블에 매핑하도록) 객체를 여기서 만들고
 
-        if( id == null ){
+        if( id == null ){ //특정 사용자가 없으면, 그냥 등록된 사고 목록 조회. . .
             incidents = incidentRepository.findAll();
-        }else{
+        }else{ //id가 있으면 특정 사용자 (userId, 즉, creatorId)가 등록한 사고만 List에 답기.
             incidents = incidentRepository.findByCreatorId(id);
         }
 

--- a/src/test/java/com/andamiro/Dashboard/Config/IncidentTestConfig.java
+++ b/src/test/java/com/andamiro/Dashboard/Config/IncidentTestConfig.java
@@ -1,15 +1,17 @@
-package com.andamiro.Dashboard.Service;
+package com.andamiro.Dashboard.Config;
 
 import com.andamiro.Dashboard.Repository.IncidentRepository;
 import com.andamiro.Dashboard.Repository.UserRepository;
+import com.andamiro.Dashboard.Service.IncidentService;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 
 @TestConfiguration //테스트 전용 설정 클래스임을 알린다.
-public class IncidentServiceTestConfig {
-
+public class IncidentTestConfig {
+    //여기서 incident관련 Service, Controller 테스트 진행할 때 @MockitoBean을 쓰면 매번 Application Context를 갈아치우니까
+    //@TestConfiguration + Bean,primary로 아예 Context에 빈 주입 생성 당시 가짜 객체를 주입하기.
 
     @Bean //스프링 컨테이너가 뜰 때, 이 메서드 실행 → 리턴값을 컨테이너에 넣어줌. 그래서 @Autowired나 생성자 주입으로 이 객체를 받아 쓸 수 있게 됨. -> IncidentRepository 타입의 Bean이 등록됨.
     @Primary //스프링 컨테이너에 IncidentRepository 타입 Bean이 여러 개 있을 수 있음. -> 우선순위 먼저 부여.
@@ -19,9 +21,19 @@ public class IncidentServiceTestConfig {
         return Mockito.mock(IncidentRepository.class);
     }
 
-    @Bean
+    @Bean //스프링 컨텍스트에 Mock 객체를 Bean으로 등록.
     @Primary
     public UserRepository mockUserRepository() {
         return Mockito.mock(UserRepository.class);
     }
+
+    @Bean
+    @Primary
+    public IncidentService mockIncidentService() {
+        return Mockito.mock(IncidentService.class);
+    }
+
+
+
+
 }

--- a/src/test/java/com/andamiro/Dashboard/Controller/IncidentControllerTest.java
+++ b/src/test/java/com/andamiro/Dashboard/Controller/IncidentControllerTest.java
@@ -1,4 +1,237 @@
 package com.andamiro.Dashboard.Controller;
 
+import com.andamiro.Dashboard.Config.IncidentTestConfig;
+import com.andamiro.Dashboard.Dto.IncidentDTO.*;
+import com.andamiro.Dashboard.Fixture.IncidentFixture;
+import com.andamiro.Dashboard.Service.IncidentService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(IncidentController.class)
+@Import(IncidentTestConfig.class) /// ← IncidentTestConfig 안의 Bean을 현재 테스트 컨텍스트에 등록
+@AutoConfigureMockMvc(addFilters = false)  // 시큐리티 필터 무시 -> 지금 IncidentController 로직 테스트만 하고 싶지, 인증/인가까지 검증하고 싶은 건 아님.
 public class IncidentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    //->컨트롤러는 Entity를 다루지 않고 Service/DTO만 다룸.
+
+    //@MockBean
+    @Autowired
+    private IncidentService incidentService; //@MockBean대신 여기서 바로 주입됨. IncidentTestConfig덕분에
+
+    @Autowired
+    private ObjectMapper objectMapper; //JSON <->DTO
+
+    /*
+    1. 요청 DTO는 IncidentFixture에서 꺼내 쓰기
+    2. 응답 DTO는 테스트 코드 내에 작성하여 가독성 확보하자.
+     */
+
+    /* 01-01 API 사고 목록 조회 매핑 */
+    @Test
+    @DisplayName("GET /incidents?id={userId}") // @ReqeustParam이라 쿼리 파라미터로
+    void getIncidentTest() throws Exception{
+        //given
+        UUID userId = UUID.randomUUID();
+
+        IncidentResponse incident1 = new IncidentResponse(
+                UUID.randomUUID(),
+                "유류 유출",
+                "oil_spill",
+                "부산항",
+                "기관실에서 기름이 유출됨",
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                "OPEN",
+                new IncidentResponse.CreatorSummary(userId, "홍길동") // 👈 여기서 creator.id 세팅됨
+        );
+
+        IncidentResponse incident2 = new IncidentResponse(
+                UUID.randomUUID(),
+                "화재",
+                "fire",
+                "울산항",
+                "기관실 화재 발생",
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                "OPEN",
+                new IncidentResponse.CreatorSummary(userId, "홍길동")
+        );
+
+        //when - 모키토 given함수 - 연관된 하위계층의 메서드 실행(given 데이터 셋업 넣으면)후 반환값 설정
+        given(incidentService.getListIncidents(eq(userId))).willReturn(List.of(incident1, incident2));
+
+        //then
+
+        mockMvc.perform(get("/incidents") //mockMvc는 스프링에서 제공하는 가짜 HTTP 클라이언트로, 컨트롤러 메서드 호출 가능.
+                        .param("id", userId.toString())) //쿼리 파라미터 붙이기
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value("유류 유출"))//$[0] - 배열의 첫번째 요소.
+                .andExpect(jsonPath("$[1].title").value("화재"))
+                .andDo(print());
+    }
+
+
+    /* 01-02 API 사고 등록 매핑 */
+    @Test
+    @DisplayName("POST /incidents") //@RequeestBody
+    void createIncidentTest() throws Exception{
+        //given - 데이터 셋업
+
+        /* 컨트롤러 메서드의 요청 DTO 객체 생성*/
+        UUID userId = UUID.randomUUID();
+        IncidentCreateRequest req = IncidentFixture.createIncidentCreateRequest(userId);
+
+        /* 컨트롤러 메서드의 응답 DTO 객체 생성 후 이걸 반환하도록 하게끔 when절에서 실행할거임.*/
+        IncidentResponse response = new IncidentResponse(
+                userId,
+                "유류 유출",
+                "OIL_SPILL",
+                "부산항",
+                "기관실에서 기름이 유출됨",
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                "OPEN",
+                new IncidentResponse.CreatorSummary(userId, "홍길동") //record의 멤버 record는 자동으로 static으로 취급돼.
+        );
+
+        //when - 실행
+        given(incidentService.createIncident(eq(req))).willReturn(response);
+
+        //then - 검증
+
+        mockMvc.perform(post("/incidents")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req))) // JSON 직렬화
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("유류 유출"))
+                .andExpect(jsonPath("$.incidentType").value("OIL_SPILL"))
+                .andExpect(jsonPath("$.creator.name").value("홍길동"))
+                .andDo(print());
+    }
+
+    /* 01-03 API 사고 상세 조회 매핑 */
+    @Test
+    @DisplayName("GET /incidents/{id}") //@PathVariable 형식임.
+    void getDetailIncidentTest() throws Exception{
+
+        //given - 요청/응답 DTO 객체 생성
+
+        UUID incidentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        IncidentDetailResponse response = new IncidentDetailResponse(
+                incidentId,
+                "유류 유출",
+                "기관실에서 기름이 유출됨",
+                "oil_spill",
+                "부산항",
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                "OPEN",
+                new IncidentDetailResponse.Creator(userId, "홍길동"),
+                List.of(
+                        new IncidentDetailResponse.EvidenceFile(
+                                UUID.randomUUID(),
+                                "http://example.com/file1.jpg",
+                                "image",
+                                "현장 사진",
+                                userId
+                        )
+                ),
+                List.of(
+                        new IncidentDetailResponse.Report(
+                                UUID.randomUUID(),
+                                "http://example.com/report1.pdf",
+                                LocalDateTime.now()
+                        )
+                )
+        );
+        //when
+        given(incidentService.getDetailIncident(eq(incidentId)))
+                .willReturn(response);
+
+        //then
+        mockMvc.perform(get("/incidents/{id}", incidentId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(incidentId.toString()))
+                .andExpect(jsonPath("$.title").value("유류 유출"))
+                .andExpect(jsonPath("$.creator.name").value("홍길동"))
+                .andExpect(jsonPath("$.evidenceFiles[0].fileUrl").value("http://example.com/file1.jpg"))
+                .andExpect(jsonPath("$.reports[0].pdfUrl").value("http://example.com/report1.pdf"))
+                .andDo(print());
+
+    }
+
+
+    /* 01-04 API 사고 수정 매핑 */
+    @Test
+    @DisplayName("PUT /incidents/{id}") //@PathVariable + @ReuqestBody
+    void updateIncidentTest() throws Exception{
+
+        //given -요청,응답 DTO 객체 생성
+        UUID incidentId = UUID.randomUUID();
+
+        IncidentUpdateRequest req = IncidentFixture.createIncidentUpdateRequest();
+        IncidentUpdateResponse response = new IncidentUpdateResponse(
+                incidentId,
+                "수정된 제목",
+                "수정된 설명 ~ ~",
+                "OIL_SPILL",
+                "울산항",
+                LocalDateTime.now().minusDays(1), // happenedAt (원래 발생 시각)
+                LocalDateTime.now()               // updatedAt (수정 시각)
+        );
+
+        //when
+        given(incidentService.updateIncident(eq(incidentId), any(IncidentUpdateRequest.class)))
+                .willReturn(response);
+
+
+        //then
+        mockMvc.perform(put("/incidents/{id}", incidentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(incidentId.toString()))
+                .andExpect(jsonPath("$.title").value("수정된 제목"))
+                .andExpect(jsonPath("$.description").value("수정된 설명 ~ ~"))
+                .andExpect(jsonPath("$.location").value("울산항"))
+                .andExpect(jsonPath("$.incidentType").value("OIL_SPILL"))
+                .andDo(print());
+    }
+
+
+    /* 01-05 API 사고 삭제 매핑 */
+    @Test
+    @DisplayName("DELETE /incidents/{id}")
+    void deleteIncidentTest() throws Exception{
+        UUID incidentId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/incidents/{id}", incidentId))
+                .andExpect(status().isNoContent())
+                .andDo(print());
+    }
+
 }

--- a/src/test/java/com/andamiro/Dashboard/Fixture/IncidentFixture.java
+++ b/src/test/java/com/andamiro/Dashboard/Fixture/IncidentFixture.java
@@ -1,0 +1,45 @@
+package com.andamiro.Dashboard.Fixture;
+
+import com.andamiro.Dashboard.Dto.IncidentDTO.IncidentCreateRequest;
+import com.andamiro.Dashboard.Dto.IncidentDTO.IncidentUpdateRequest;
+import com.andamiro.Dashboard.Entity.Incident;
+import com.andamiro.Dashboard.Entity.User;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class IncidentFixture {
+
+    /*요청 DTO 객체 생성 */
+    public static IncidentCreateRequest createIncidentCreateRequest(UUID userId) {
+        return new IncidentCreateRequest(
+                userId,
+                "유류 유출",
+                "기관실에서 기름이 유출됨",
+                "OIL_SPILL",
+                "부산항",
+                LocalDateTime.now()
+        );
+    }
+
+    public static IncidentUpdateRequest createIncidentUpdateRequest() {
+        return new IncidentUpdateRequest(
+                "수정된 제목",
+                "수정된 설명 ~ ~",
+                "울산항"
+        );
+    }
+
+    /*엔티티 객체 생성 */
+    //->ServiceTest에서 Incident 엔티티를 직접 만들어 써야 할 때 중복 줄이려고 추가한 것.
+    public static Incident oilSpillIncident(User owner) {
+        return Incident.create(
+                owner,
+                "유류 유출",
+                "기관실에서 기름이 유출됨",
+                Incident.IncidentType.OIL_SPILL,
+                "부산항",
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/test/java/com/andamiro/Dashboard/Repository/IncidentRepositoryTest.java
+++ b/src/test/java/com/andamiro/Dashboard/Repository/IncidentRepositoryTest.java
@@ -1,4 +1,51 @@
 package com.andamiro.Dashboard.Repository;
 
+import com.andamiro.Dashboard.Entity.Incident;
+import com.andamiro.Dashboard.Entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@DataJpaTest                // JPA 관련 Bean만 로딩 (Repository, EntityManager 등)
+@ActiveProfiles("test")     // application-test.yml 적용 보장
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)  //DataJpaTest → TestDatabaseAutoConfiguration → H2 등 임베디드 DB로 대체 시도
+//MySQL 연결하고 싶음 → replace = NONE으로 지정하면 application-test.yml의 설정을 그대로 사용합니다.
 public class IncidentRepositoryTest {
+
+    @Autowired
+    private IncidentRepository incidentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("findByCreatorId는 특정 사용자가 등록한 사건만 반환한다")
+    void findByCreatorIdTest() {
+        // given
+        User owner1 = userRepository.save(User.create("a@test.com", "pw", "홍길동", User.Role.OWNER));
+        User owner2 = userRepository.save(User.create("b@test.com", "pw", "김철수", User.Role.OWNER));
+
+        incidentRepository.save(
+                Incident.create(owner1, "유류 유출", "기관실 기름 유출", Incident.IncidentType.OIL_SPILL, "부산항", LocalDateTime.now())
+        );
+        incidentRepository.save(
+                Incident.create(owner2, "화재", "기관실 화재", Incident.IncidentType.FIRE, "울산항", LocalDateTime.now())
+        );
+
+        // when
+        List<Incident> result = incidentRepository.findByCreatorId(owner1.getId());
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getTitle()).isEqualTo("유류 유출");
+        assertThat(result.get(0).getCreator().getName()).isEqualTo("홍길동");
+    }
 }

--- a/src/test/java/com/andamiro/Dashboard/Service/IncidentServiceTest.java
+++ b/src/test/java/com/andamiro/Dashboard/Service/IncidentServiceTest.java
@@ -1,5 +1,6 @@
 package com.andamiro.Dashboard.Service;
 
+import com.andamiro.Dashboard.Config.IncidentTestConfig;
 import com.andamiro.Dashboard.Dto.IncidentDTO.IncidentCreateRequest;
 import com.andamiro.Dashboard.Dto.IncidentDTO.IncidentResponse;
 import com.andamiro.Dashboard.Dto.IncidentDTO.IncidentUpdateRequest;
@@ -10,7 +11,6 @@ import com.andamiro.Dashboard.Repository.IncidentRepository;
 import com.andamiro.Dashboard.Repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -25,7 +25,7 @@ import static org.assertj.core.api.BDDAssertions.then; //값 검증
 
 //프로젝트 전체 Bean을 다 올리는데, 실서비스 환경과 똑같이 동작함. 다만 너무 무거워서 아래와같은 옵션을 줘서 올릴 Bean을 제한하였음.
 //classes={(테스트할 대상), (Mock Repository를 Bean으로 등록해주는 설정)}
-@SpringBootTest(classes = {IncidentService.class, IncidentServiceTestConfig.class})
+@SpringBootTest(classes = {IncidentService.class, IncidentTestConfig.class})
 public class IncidentServiceTest {
     //테스트할 Service + 필요한 Mock Bean만 최소한으로 ApllicationContext에 띄운다.
     @Autowired

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/dashboard_test?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${TEST_DB_USER}
+    password: ${TEST_DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop   # 테스트 실행할 때마다 테이블 새로 만들고 종료 후 삭제
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+


### PR DESCRIPTION
TEST : IncidentControllerTest, IncidentRepositoryTest 테스트 코드 작성 및 성공

문제) Repository 테스트 중, H2 DB 사용 시 users 테이블 인식을 못하였음. 대소문자 구분을 해서, 엔티티 @Table(name="users")를 다시 "USERS"로 매번 바꿔야하는 게 고생길이 보였음.

* 해당 문제는 아래와 같이 해결함.

해결) 로컬 Mysql 에서 테스트용 DB 및 유저 설정 + Test 클래스 실행 - 구성 편집 - 환경변수 기입하였음. (application-test.yml)