### PR TITLE
fix : pdf 보고서 다운로드 재시도 횟수 5->15회로 늘림

### DIFF
--- a/src/main/java/com/andamiro/Dashboard/Service/ReportService.java
+++ b/src/main/java/com/andamiro/Dashboard/Service/ReportService.java
@@ -166,7 +166,7 @@ public class ReportService {
     }
 
     public byte[] retryDownloadReport(String taskId) throws InterruptedException {
-        int attempts = 5;
+        int attempts = 15;
         for (int i = 0; i < attempts; i++) {
             try {
                 return fastApiClient.downloadReport(taskId);


### PR DESCRIPTION
PDF 생성 속도는 LLM 응답 속도 + PDF 렌더링에 따라 달라지므로 고정 시간이 아니라 반복 확인 기반이 안전함.